### PR TITLE
feat: 3 papers y 1 informe en .bib

### DIFF
--- a/docs/bibliografía.bib
+++ b/docs/bibliografía.bib
@@ -56,3 +56,47 @@
   doi       = {10.1201/9781032641522},
   url       = {https://www.paulamoraga.com/book-spatial/}
 }
+
+@article{Gamboa2021,
+  author    = {Gamboa-Gamboa, Tatiana and Fantin, Romain and Cordoba, Jeancarlo and Caravaca, Ivannia and Gómez-Duarte, Ingrid},
+  title     = {Relationship between childhood obesity and socio-economic status among primary school children in Costa Rica},
+  journal   = {Public Health Nutrition},
+  volume    = {24},
+  number    = {12},
+  pages     = {3825--3833},
+  year      = {2021},
+  doi       = {10.1017/S1368980021002032},
+  url       = {https://doi.org/10.1017/S1368980021002032}
+}
+
+@article{Nunez2022,
+  author    = {Núñez-Rivas, Hazel P. and Holst-Schumacher, Ingrid and Campos-Saborío, Natalia and López-López, Erick},
+  title     = {Percentiles of body mass index and waist circumference for Costa Rican children and adolescents. Percentiles de índice de masa corporal y circunferencia de la cintura en niños y adolescentes de Costa Rica},
+  journal   = {Nutrición Hospitalaria},
+  volume    = {39},
+  number    = {6},
+  pages     = {1228--1236},
+  year      = {2022},
+  doi       = {10.20960/nh.04130},
+  url       = {https://doi.org/10.20960/nh.04130}
+}
+
+@article{Hernandez2016,
+  author    = {Hernández-Vásquez, Akram and Bendezú-Quispe, Guido and Díaz-Seijas, Deysi and Santero, Marilina and Minckas, Nicole and Azañedo, Diego and Antiporta, Daniel A.},
+  title     = {Análisis espacial del sobrepeso y la obesidad infantil en el Perú, 2014 [Spatial analysis of childhood obesity and overweight in Peru, 2014]},
+  journal   = {Revista Peruana de Medicina Experimental y Salud Pública},
+  volume    = {33},
+  number    = {3},
+  pages     = {489--497},
+  year      = {2016},
+  doi       = {10.17843/rpmesp.2016.333.2298},
+  url       = {https://doi.org/10.17843/rpmesp.2016.333.2298}
+}
+
+@misc{WHO2018,
+  author    = {{World Health Organization}},
+  title     = {Taking action on childhood obesity},
+  year      = {2018},
+  howpublished = {\url{https://apps.who.int/iris/bitstream/handle/10665/274792/WHO-NMH-PND-ECHO-18.1-eng.pdf}},
+  note      = {Accessed: 2025-09-03}
+}


### PR DESCRIPTION
nombres de los papers:

- Relación entre la obesidad infantil y el nivel socioeconómico en niños de primaria en Costa Rica
- Percentiles del índice de masa corporal y circunferencia de cintura de niños y adolescentes costarricenses
- Análisis espacial de la obesidad y el sobrepeso infantil en el Perú, 2014